### PR TITLE
Use stable version for friendsofsymfony/user-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "doctrine/doctrine-cache-bundle": "^1.2",
         "doctrine/orm": "^2.5",
         "friendsofsymfony/jsrouting-bundle": "^1.6",
-        "friendsofsymfony/user-bundle": "~2.0@dev",
+        "friendsofsymfony/user-bundle": "~2.0",
         "incenteev/composer-parameter-handler": "^2.0",
         "liip/imagine-bundle": "^1.7",
         "sensio/distribution-bundle": "^5.0",


### PR DESCRIPTION
As i tried to install your demo project, it gives me some errors on composer install. I think it's because of the Symfony 4 changes made in FOSUserBundle in the dev package.

I changed stability for FOSUserBundle to stable and now it's working again. Perhaps you can merge this PR?

